### PR TITLE
fix(exos-cli): Fix package-lock.json

### DIFF
--- a/packages/exos-cli/package-lock.json
+++ b/packages/exos-cli/package-lock.json
@@ -5490,9 +5490,9 @@
       "dev": true
     },
     "exos-scripts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/exos-scripts/-/exos-scripts-0.3.0.tgz",
-      "integrity": "sha512-Xi3QOKLIjIoG0earMgRCpjNhw2PRLuNyXigoF4oBlUx6/KjTQ4moNkgcp+P3mhACroCT/KDZEP6AmiIp0TlISQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/exos-scripts/-/exos-scripts-0.3.1.tgz",
+      "integrity": "sha512-+dZw7D8sCM4AjQVwavlhNhZFGdPx49FL/g6kbsbhNcmrmI1EYvYz6HhXzSX+x4zMTdC/XGxyyi0oOBD7AyjYSg==",
       "dev": true,
       "requires": {
         "@svgr/webpack": "^5.3.0",
@@ -7359,6 +7359,16 @@
         "jest-cli": "^25.3.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -7399,18 +7409,6 @@
             "prompts": "^2.0.1",
             "realpath-native": "^2.0.0",
             "yargs": "^15.3.1"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            }
           }
         },
         "locate-path": {


### PR DESCRIPTION
When trying to do `npm ci` in `exos-cli`, the following error occurs:

```
$ npm ci
npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```

Fix this by doing `npm install` and committing the new generated `package-lock.json`.