### PR TITLE
fix(exos-scripts): Add missing dep and fix typos

### DIFF
--- a/packages/exos-scripts/package.json
+++ b/packages/exos-scripts/package.json
@@ -49,6 +49,7 @@
     "style-loader": "^1.1.3",
     "ts-jest": "^25.3.1",
     "ts-loader": "^6.2.2",
+    "tslib": "^1.11.1",
     "url-loader": "^4.0.0",
     "webpack": "^4.42.1",
     "webpack-dev-server": "^3.10.3"

--- a/packages/exos-scripts/src/scripts/test/index.ts
+++ b/packages/exos-scripts/src/scripts/test/index.ts
@@ -8,7 +8,7 @@ import jest from "jest";
 import getConfigToUse from "../../common/getConfigToUse";
 import hasArgument from "../../common/hasArgument";
 import jestConfig = require("./jest.config");
-import { Config } from "@jest/types";
+import type { Config } from "@jest/types";
 
 // Get config path (default or custom)
 const configToUse = getConfigToUse<Config.Argv>("test.js", jestConfig as any);

--- a/packages/exos-scripts/src/scripts/test/index.ts
+++ b/packages/exos-scripts/src/scripts/test/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import * as jest from "jest";
+import jest from "jest";
 import getConfigToUse from "../../common/getConfigToUse";
 import hasArgument from "../../common/hasArgument";
 import jestConfig = require("./jest.config");
-import type { Config } from "@jest/types";
+import { Config } from "@jest/types";
 
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = "test";
@@ -23,7 +23,7 @@ if (isCI && !hasArgument(argv, "--coverage")) {
   argv.push("--coverage");
 }
 
-// If it's no CI and we arenot collecting coverage,
+// If it's no CI and we are not collecting coverage,
 // run in watchAll mode (unless explicitly declared otherwise)
 if (!isCI && !hasArgument(argv, "--coverage") && !hasArgument(argv, "--watchAl")) {
   argv.push("--watchAll");


### PR DESCRIPTION
This PR adds the `tslib` dependency that is required when building with the `importHelpers` property in typescript. It also fixes a comment typo, a lacking comma and a `* as` import that shouldn't exist because typescript is using `esModuleInterop` when compiling.

I would also like to start a discussion about this file.
- Why are we setting a `test` environment? this environment is set by default by Jest when running the tests.
- Why did you call the config file `test.js` ? It's a Jest config file, it won't ever be compatible with any other testing framework and it's not an interface that was made for this project. It think this file should be super explicit that this is a jest config file.
- Jest automatically identifies if it's a CI environment or not. Any custom operations, like coverage if it's in CI mode should be done by the user in the jest config file. It's super confusing for the user to have to set an environment variable if it's in a CI environment when Jest already identifies that.
- Why would a user want to be in watch mode every time the want tu run a test? This seems pretty annoying.