### PR TITLE
fix(exos-scripts): Remove auto set up of Jest properties in test script

### DIFF
--- a/packages/exos-cli/src/commands/init/command.ts
+++ b/packages/exos-cli/src/commands/init/command.ts
@@ -116,7 +116,7 @@ export default function command(argv: CommandArguments): void {
   console.log();
 
   console.log(chalk.cyan(`npm run test`));
-  console.log("  Starts the test runner in watch mode.");
+  console.log("  Executes the test runner in all of your test files.");
   console.log();
 
   console.log(chalk.cyan(`npm run lint`));

--- a/packages/exos-scripts/README.md
+++ b/packages/exos-scripts/README.md
@@ -6,9 +6,10 @@ It contains the following built-in features:
 
 - `exos-scripts start`: A ready-to-be-used development experience as similar to production as it could be.
 - `exos-scripts build`: A build script for web applications, configured and optimized to provide the best performance.
-- `exos-scripts test`: A unit testing framework and coverage already configured for you ([Jest](https://jestjs.io/)).
-- `exos-scriptsn lint`: a static analyzer tool configured with the best practices for development with [React](https://reactjs.org/), [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/).
-  - `exos-scriptsn lint --type=Library`: Also comes with a flavor for Node Libraries using [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/).
+- `exos-scripts test`: A unit testing framework ([Jest](https://jestjs.io/)) already configured for you.
+  - `CI=true exos-scripts test`: Also comes with coverage configured that will be executed by default in CI environments. You can trigger it this way or by running `exos-scripts test --collectCoverage`.
+- `exos-scripts lint`: a static analyzer tool configured with the best practices for development with [React](https://reactjs.org/), [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/).
+  - `exos-scripts lint --type=Library`: Also comes with a flavor for Node Libraries using [TypeScript](https://www.typescriptlang.org/), [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/).
 
 > **Note:** For more information about the **🛡️Exos** initiative, click [here](https://github.com/nanovazquez/exos).
 

--- a/packages/exos-scripts/src/scripts/test/index.ts
+++ b/packages/exos-scripts/src/scripts/test/index.ts
@@ -6,7 +6,6 @@ if (!process.env.NODE_ENV) {
 
 import * as jest from "jest";
 import getConfigToUse from "../../common/getConfigToUse";
-import hasArgument from "../../common/hasArgument";
 import jestConfig = require("./jest.config");
 import type { Config } from "@jest/types";
 
@@ -15,19 +14,6 @@ const configToUse = getConfigToUse<Config.Argv>("test.js", jestConfig as any);
 console.info(configToUse.isCustom ? `Found custom test config at ${configToUse.customConfigPath}` : "Using default test config");
 
 const argv = process.argv.slice(2);
-const isCI = !!process.env.CI;
-
-// If the CI environment variable is set,
-// run coverage (unless explicitly declared otherwise)
-if (isCI && !hasArgument(argv, "--coverage")) {
-  argv.push("--coverage");
-}
-
-// If it's no CI and we arenot collecting coverage,
-// run in watchAll mode (unless explicitly declared otherwise)
-if (!isCI && !hasArgument(argv, "--coverage") && !hasArgument(argv, "--watchAl")) {
-  argv.push("--watchAll");
-}
 
 // Run Jest with config and arguments
 argv.push("--config", JSON.stringify(configToUse.config));

--- a/packages/exos-scripts/src/scripts/test/jest.config.js
+++ b/packages/exos-scripts/src/scripts/test/jest.config.js
@@ -5,4 +5,6 @@ module.exports = {
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  // If the CI environment variable is set, runc overage
+  collectCoverage: !!process.env.CI,
 };

--- a/packages/exos-scripts/src/scripts/test/jest.config.js
+++ b/packages/exos-scripts/src/scripts/test/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
   },
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  // If the CI environment variable is set, runc overage
+  // If the CI environment variable is set, run coverage
   collectCoverage: !!process.env.CI,
 };


### PR DESCRIPTION
This PR removes the auto config of `watchAll` and `collectCoverage` through code.

Instead, we'll keep enabling coverage in CI environments, but the user can opt out from this via configuration